### PR TITLE
Added support for Map type

### DIFF
--- a/DynamoDBWrapper.php
+++ b/DynamoDBWrapper.php
@@ -424,6 +424,9 @@ class DynamoDBWrapper
             else if (isset($v['BS'])) {
                 $converted[$k] = $v['BS'];
             }
+            else if (isset($v['M'])) {
+                $converted[$k] = $v['M'];
+            }
             else {
                 throw new Exception('Not implemented type');
             }


### PR DESCRIPTION
Recently I found that this wrapper does not have support for Map type (https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html).