### PR TITLE
Update to Scan function.

### DIFF
--- a/DynamoDBWrapper.php
+++ b/DynamoDBWrapper.php
@@ -124,6 +124,12 @@ class DynamoDBWrapper
         $items = $this->client->getIterator('Scan', array(
             'TableName' => $tableName,
             'ScanFilter' => $scanFilter,
+            'ScanIndexForward' => true,
+            'Limit' => $limit
+            ),
+            array(
+                'limit' => $limit
+            )
         ));
         return $this->convertItems($items);
     }


### PR DESCRIPTION
The Limit value was not used, so I added, ok. 
The param "ScanIndexForward" can be added like the Query function "$options" in the future. 
By default, the sort order is already ascending "true" by AWS. To reverse the order, set the ScanIndexForward parameter to false. 
Someday I will update using the same approach as $options = array() in query.